### PR TITLE
Adapting PostgreSqlDialect to 8.0.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -12,7 +12,7 @@
 Name=Mondrian
 name=mondrian
 vendor=Pentaho
-project.revision=3.10.0.1-134
+project.revision=3.10.0.1-135
 project.revision.major=3
 project.revision.minor=100
 ivy.artifact.id=mondrian

--- a/src/main/mondrian/olap4j/MondrianOlap4jLevel.java
+++ b/src/main/mondrian/olap4j/MondrianOlap4jLevel.java
@@ -32,7 +32,7 @@ import java.util.*;
  * @author jhyde
  * @since May 25, 2007
  */
-class MondrianOlap4jLevel
+public class MondrianOlap4jLevel
     extends MondrianOlap4jMetadataElement
     implements Level, Named
 {
@@ -212,6 +212,10 @@ class MondrianOlap4jLevel
 
     protected OlapElement getOlapElement() {
         return level;
+    }
+
+    public mondrian.olap.Level getLevel() {
+    	return level;
     }
 }
 

--- a/src/main/mondrian/spi/impl/PostgreSqlDialect.java
+++ b/src/main/mondrian/spi/impl/PostgreSqlDialect.java
@@ -128,7 +128,7 @@ public class PostgreSqlDialect extends JdbcDialectImpl {
     
     @Override
     public String getCurrentSchemaQuery() {
-    	return "select current_schema";
+    	return "select current_schema()";
     }
 }
 


### PR DESCRIPTION
Postgres' current_schema up to Pg 8.3 requires trailing parentheses. From 8.4 they are optional.
RedShift is based on 8.0.2, so we need them in PostgreSqlDialect or RedshiftSqlDialect.